### PR TITLE
Add description (optional) when creating a tree

### DIFF
--- a/astpk.py
+++ b/astpk.py
@@ -181,7 +181,7 @@ def deploy(snapshot):
         print(f"{snapshot} was deployed to /")
 
 # Add node to branch
-def extend_branch(snapshot):
+def extend_branch(snapshot, desc=""):
     if not (os.path.exists(f"/.snapshots/rootfs/snapshot-{snapshot}")):
         print("cannot branch, snapshot doesn't exist")
     else:
@@ -192,6 +192,7 @@ def extend_branch(snapshot):
         os.system(f"btrfs sub snap -r /.snapshots/boot/boot-{snapshot} /.snapshots/boot/boot-{i} >/dev/null 2>&1")
         add_node_to_parent(fstree,snapshot,i)
         write_tree(fstree)
+        if desc: write_desc(i, desc)
         print(f"branch {i} added to {snapshot}")
 
 # Clone branch under same parent,
@@ -352,15 +353,15 @@ def clone_as_tree(snapshot):
         print(f"tree {i} cloned from {snapshot}")
 
 # Creates new tree from base file
-def new_snapshot():
+def new_snapshot(desc=""):
     i = findnew()
     os.system(f"btrfs sub snap -r /.snapshots/rootfs/snapshot-0 /.snapshots/rootfs/snapshot-{i} >/dev/null 2>&1")
     os.system(f"btrfs sub snap -r /.snapshots/etc/etc-0 /.snapshots/etc/etc-{i} >/dev/null 2>&1")
     os.system(f"btrfs sub snap -r /.snapshots/boot/boot-0 /.snapshots/boot/boot-{i} >/dev/null 2>&1")
     os.system(f"btrfs sub snap -r /.snapshots/var/var-0 /.snapshots/var/var-{i} >/dev/null 2>&1")
-#    append_base_tree(fstree, i)
     append_base_tree(fstree,i)
     write_tree(fstree)
+    if desc: write_desc(i, desc)
     print(f"new tree {i} created")
 
 # Calls print function

--- a/astpk.py
+++ b/astpk.py
@@ -640,11 +640,9 @@ def check_update():
     upstate.close()
 
 def chroot_check():
-    chroot = True # When inside chroot
-    with open("/proc/mounts", "r") as mounts:
-        for line in mounts:
-            if str("/.snapshots btrfs") in str(line):
-                chroot = False
+	chroot = True
+	#If following command succeeds with exit code 0, definitely not inside chroot
+    if not os.system("unshare -U True"): chroot = False
     return(chroot)
 
 # Rollback last booted deployment

--- a/main.py
+++ b/main.py
@@ -257,13 +257,13 @@ def main(args):
     if efi:
         os.system("umount /mnt/boot/efi")
 #    os.system("mkdir /mnt/.snapshots/var/var-tmp")
-    os.system("mkdir /mnt/.snapshots/boot/boot-tmp")
+#    os.system("mkdir /mnt/.snapshots/boot/boot-tmp")
 #    os.system(f"mount {args[1]} -o subvol=@var,compress=zstd,noatime /mnt/.snapshots/var/var-tmp")
     os.system(f"mount {args[1]} -o subvol=@boot,compress=zstd,noatime /mnt/.snapshots/boot/boot-tmp")
 #    os.system("cp --reflink=auto -r /mnt/.snapshots/var/var-tmp/* /mnt/var")
     os.system("cp --reflink=auto -r /mnt/.snapshots/boot/boot-tmp/* /mnt/boot")
     os.system("umount /mnt/etc")
-    os.system("mkdir /mnt/.snapshots/etc/etc-tmp")
+#    os.system("mkdir /mnt/.snapshots/etc/etc-tmp")
     os.system(f"mount {args[1]} -o subvol=@etc,compress=zstd,noatime /mnt/.snapshots/etc/etc-tmp")
     os.system("cp --reflink=auto -r /mnt/.snapshots/etc/etc-tmp/* /mnt/etc")
     if DesktopInstall:


### PR DESCRIPTION
Add a description right at same time of creating a tree if it is included in the arguments passed. For example:

`ast branch 1 sway` will do both these:
1. `ast branch 1` (say this creates node _4_)
2. `ast desc 4 sway`

This way one doesn't need to ast tree and see the number of newly created branch!