### PR TITLE
revert chroot_check

### DIFF
--- a/astpk.py
+++ b/astpk.py
@@ -629,9 +629,11 @@ def check_update():
     upstate.close()
 
 def chroot_check():
-    chroot = True
-    #If following command succeeds with exit code 0, definitely not inside chroot
-    if not os.system("unshare -U true"): chroot = False
+    chroot = True # When inside chroot
+    with open("/proc/mounts", "r") as mounts:
+        for line in mounts:
+            if str("/.snapshots btrfs") in str(line):
+                chroot = False
     return(chroot)
 
 # Rollback last booted deployment


### PR DESCRIPTION
I'm reverting chroot_check to old version, even though new implementation was slicker! The reason is NOT the error ast inside chroot (which I think is because of a few line above in the code). But rather because I want us to move towards distro-agnostism.

I want astpk.py to be as minimal and self-contained as possible and not depend on other utils. unshare is part of util-linux (which is quite basic) but when we become Arch-agnostic, there is one less to worry about. For instance, another distro might not have unshare or have a weird implementation of it.