### PR TITLE
A few small changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # astOS (Arch Snapshot Tree OS)
+
 ### An immutable Arch based distribution utilizing btrfs snapshots
 
 ![astos-logo](logo.jpg)
@@ -6,20 +7,21 @@
 ---
 
 ## Table of contents
-* [What is astOS?](https://github.com/CuBeRJAN/astOS#what-is-astos)
-* [astOS compared to other similar distributions](https://github.com/CuBeRJAN/astOS#astos-compared-to-other-similar-distributions)
-* [ast and astOS documentation](https://github.com/CuBeRJAN/astOS#additional-documentation)
-  * [Installation](https://github.com/CuBeRJAN/astOS#installation)
-  * [Post installation](https://github.com/CuBeRJAN/astOS#post-installation-setup)
-  * [Snapshot management and deployments](https://github.com/CuBeRJAN/astOS#snapshot-management)
-  * [Package management](https://github.com/CuBeRJAN/astOS#package-management)
-* [Additional documentation](https://github.com/CuBeRJAN/astOS#additional-documentation)
-  * [Updating the pacman keys](https://github.com/CuBeRJAN/astOS#fixing-pacman-corrupt-packages--key-issues)
-  * [Configuring dual boot](https://github.com/CuBeRJAN/astOS#dual-boot)
-  * [Updating ast itself](https://github.com/CuBeRJAN/astOS#updating-ast-itself)
-* [Known bugs](https://github.com/CuBeRJAN/astOS#known-bugs)
-* [Contributing](https://github.com/CuBeRJAN/astOS#contributing)
-* [Community](https://github.com/CuBeRJAN/astOS#community)
+
+- [What is astOS?](https://github.com/CuBeRJAN/astOS#what-is-astos)
+- [astOS compared to other similar distributions](https://github.com/CuBeRJAN/astOS#astos-compared-to-other-similar-distributions)
+- [ast and astOS documentation](https://github.com/CuBeRJAN/astOS#additional-documentation)
+  - [Installation](https://github.com/CuBeRJAN/astOS#installation)
+  - [Post installation](https://github.com/CuBeRJAN/astOS#post-installation-setup)
+  - [Snapshot management and deployments](https://github.com/CuBeRJAN/astOS#snapshot-management)
+  - [Package management](https://github.com/CuBeRJAN/astOS#package-management)
+- [Additional documentation](https://github.com/CuBeRJAN/astOS#additional-documentation)
+  - [Updating the pacman keys](https://github.com/CuBeRJAN/astOS#fixing-pacman-corrupt-packages--key-issues)
+  - [Configuring dual boot](https://github.com/CuBeRJAN/astOS#dual-boot)
+  - [Updating ast itself](https://github.com/CuBeRJAN/astOS#updating-ast-itself)
+- [Known bugs](https://github.com/CuBeRJAN/astOS#known-bugs)
+- [Contributing](https://github.com/CuBeRJAN/astOS#contributing)
+- [Community](https://github.com/CuBeRJAN/astOS#community)
 
 ---
 
@@ -30,64 +32,71 @@ Unlike Arch it uses an immutable (read-only) root filesystem.
 Software is installed and configured into individual snapshot trees, which can then be deployed and booted into.
 It doesn't use it's own package format or package manager, instead relying on [pacman](https://wiki.archlinux.org/title/pacman) from Arch.
 
-
 **This has several advantages:**
 
-* Security
-  * Even if running an application with eleveted permissions, it cannot replace system libraries with malicious versions
-* Stability and reliability
-  * Due to the system being mounted as read only, it's not possible to accidentally overwrite system files
-  * If the system runs into issues, you can easily rollback the last working snapshot within minutes
-  * Atomic updates - Updating your system all at once is more reliable
-  * Thanks to the snapshot feature, astOS can ship cutting edge software without becoming unstable
-  * astOS needs little maintenance, as it has a built in fully automatic update tool that creates snapshots before updates and automatically checks if the system upgraded properly before deploying the new snapshot
-* Configurability
-  * With the snapshots organised into a tree, you can easily have multiple different configurations of your software available, with varying packages, without any interference
-  * For example: you can have a single Gnome desktop installed and then have 2 snapshots on top - one with your video games, with the newest kernel and drivers, and the other for work, with the LTS kernel and more stable software, you can then easily switch between these depending on what you're trying to do
-  * You can also easily try out software without having to worry about breaking your system or polluting it with unnecessary files, for example you can try out a new desktop environment in a snapshot and then delete the snapshot after, without modifying your main system at all
-  * This can also be used for multi-user systems, where each user has a completely separate system with different software, and yet they can share certain packages such as kernels and drivers
-  * astOS allows you to install software by chrooting into snapshots, therefore you can use software such as the AUR to install additional packages
-  * astOS is, just like Arch, very customizable, you can choose exactly which software you want to use
+- Security
+  - Even if running an application with eleveted permissions, it cannot replace system libraries with malicious versions
+- Stability and reliability
+  - Due to the system being mounted as read only, it's not possible to accidentally overwrite system files
+  - If the system runs into issues, you can easily rollback the last working snapshot within minutes
+  - Atomic updates - Updating your system all at once is more reliable
+  - Thanks to the snapshot feature, astOS can ship cutting edge software without becoming unstable
+  - astOS needs little maintenance, as it has a built in fully automatic update tool that creates snapshots before updates and automatically checks if the system upgraded properly before deploying the new snapshot
+- Configurability
 
-* Thanks to it's reliabilty and automatic upgrades, astOS is well suitable for single use or embedded devices
-* It also makes for a good workstation or general use distribution utilizing development containers and flatpak for desktop applications 
+  - With the snapshots organised into a tree, you can easily have multiple different configurations of your software available, with varying packages, without any interference
+  - For example: you can have a single Gnome desktop installed and then have 2 snapshots on top - one with your video games, with the newest kernel and drivers, and the other for work, with the LTS kernel and more stable software, you can then easily switch between these depending on what you're trying to do
+  - You can also easily try out software without having to worry about breaking your system or polluting it with unnecessary files, for example you can try out a new desktop environment in a snapshot and then delete the snapshot after, without modifying your main system at all
+  - This can also be used for multi-user systems, where each user has a completely separate system with different software, and yet they can share certain packages such as kernels and drivers
+  - astOS allows you to install software by chrooting into snapshots, therefore you can use software such as the AUR to install additional packages
+  - astOS is, just like Arch, very customizable, you can choose exactly which software you want to use
+
+- Thanks to it's reliabilty and automatic upgrades, astOS is well suitable for single use or embedded devices
+- It also makes for a good workstation or general use distribution utilizing development containers and flatpak for desktop applications
 
 ---
+
 ## astOS compared to other similar distributions
-* **NixOS** - compared to nixOS, astOS is a more traditional system with how it's setup and maintained. While nixOS is entirely configured using the Nix programming language, astOS uses Arch's pacman package manager. astOS consumes less storage, and configuring your system is faster and easier (less reproducible however), it also gives you more customization options. astOS is FHS compliant, ensuring proper software compatability.
-  * astOS allows declarative configuration using Ansible, for somewhat similar functionality to NixOS
-* **Fedora Silverblue/Kinoite** - astOS is more customizable, but does require more manual setup. astOS supports dual boot, unlike Silverblue.
-* **OpenSUSE MicroOS** - astOS is a more customizable system, but once again requires a bit more manual setup. MicroOS works similarly in the way it utilizes btrfs snapshots. astOS has an official KDE install, but also supports other desktop environments, while MicroOS only properly supports Gnome. astOS supports dual boot.
+
+- **NixOS** - compared to nixOS, astOS is a more traditional system with how it's setup and maintained. While nixOS is entirely configured using the Nix programming language, astOS uses Arch's pacman package manager. astOS consumes less storage, and configuring your system is faster and easier (less reproducible however), it also gives you more customization options. astOS is FHS compliant, ensuring proper software compatability.
+  - astOS allows declarative configuration using Ansible, for somewhat similar functionality to NixOS
+- **Fedora Silverblue/Kinoite** - astOS is more customizable, but does require more manual setup. astOS supports dual boot, unlike Silverblue.
+- **OpenSUSE MicroOS** - astOS is a more customizable system, but once again requires a bit more manual setup. MicroOS works similarly in the way it utilizes btrfs snapshots. astOS has an official KDE install, but also supports other desktop environments, while MicroOS only properly supports Gnome. astOS supports dual boot.
 
 ---
+
 ## Installation
-* astOS is installed from the official Arch Linux live iso available on [https://archlinux.org/](https://archlinux.org)
-* If you run into issues installing packages during installation, make sure you're using the newest arch iso, and if needed update the pacman keyring
-* You need an internet connection to install astOS
-* Currently astOS ships 3 installation profiles, one for minimal installs and two for desktop, one with the Gnome desktop environment and one with KDE Plasma, but support for more DE's will be added
-* The installation script is easily configurable and adjusted for your needs (but it works just fine without any modifications)
+
+- astOS is installed from the official Arch Linux live iso available on [https://archlinux.org/](https://archlinux.org)
+- If you run into issues installing packages during installation, make sure you're using the newest arch iso, and if needed update the pacman keyring
+- You need an internet connection to install astOS
+- Currently astOS ships 3 installation profiles, one for minimal installs and two for desktop, one with the Gnome desktop environment and one with KDE Plasma, but support for more DE's will be added
+- The installation script is easily configurable and adjusted for your needs (but it works just fine without any modifications)
 
 Install git first - this will allow us to download the install script
 
 ```
 pacman -Sy git
 ```
+
 Clone repository
 
 ```
-git clone "https://github.com/CuBeRJAN/astOS"  
-cd astOS  
+git clone "https://github.com/CuBeRJAN/astOS"
+cd astOS
 ```
+
 Partition and format drive
 
-* If installing on a BIOS system, use a dos (MBR) partition table
-* On EFI you can use GPT
-* The EFI partition has to be formatted to FAT32 before running the installer (```mkfs.fat -F32 /dev/<part>```)
+- If installing on a BIOS system, use a dos (MBR) partition table
+- On EFI you can use GPT
+- The EFI partition has to be formatted to FAT32 before running the installer (`mkfs.fat -F32 /dev/<part>`)
 
 ```
 lsblk  # Find your drive name
-cfdisk /dev/*** # Format drive, make sure to add an EFI partition, if using BIOS leave 2M free space before first partition  
+cfdisk /dev/*** # Format drive, make sure to add an EFI partition, if using BIOS leave 2M free space before first partition
 ```
+
 Run installer
 
 ```
@@ -95,24 +104,27 @@ python3 main.py /dev/<partition> /dev/<drive> /dev/<efi part> # Skip the EFI par
 ```
 
 ## Post installation setup
-* Post installation setup is not necessary if you install one of the desktop editions (Gnome or KDE)
-* A lot of information for how to handle post-install setup is available on the [ArchWiki page](https://wiki.archlinux.org/title/general_recommendations) 
-* Here is a small example setup procedure:
-  * Start by creating a new snapshot from the base image using ```ast clone 0```
-  * Chroot inside this new snapshot (```ast chroot <snapshot>```) and begin setup
-    * Start by adding a new user account: ```useradd username```
-    * Set the user password ```passwd username```
-    * Now set a new password for root user ```passwd root```
-    * Now you can install additional packages (desktop environments, container technologies, flatpak) using pacman
-    * Once done, exit the chroot with ```exit```
-    * Then you can deploy it with ```ast deploy <snapshot>```
+
+- Post installation setup is not necessary if you install one of the desktop editions (Gnome or KDE)
+- A lot of information for how to handle post-install setup is available on the [ArchWiki page](https://wiki.archlinux.org/title/general_recommendations)
+- Here is a small example setup procedure:
+  - Start by creating a new snapshot from the base image using `ast clone 0`
+  - Chroot inside this new snapshot (`ast chroot <snapshot>`) and begin setup
+    - Start by adding a new user account: `useradd username`
+    - Set the user password `passwd username`
+    - Now set a new password for root user `passwd root`
+    - Now you can install additional packages (desktop environments, container technologies, flatpak) using pacman
+    - Once done, exit the chroot with `exit`
+    - Then you can deploy it with `ast deploy <snapshot>`
 
 ## Additional documentation
-* It is advised to refer to the [Arch wiki](https://wiki.archlinux.org/) for documentation not part of this project
-* Report issues/bugs on the [Github issues page](https://github.com/CuBeRJAN/astOS/issues)
+
+- It is advised to refer to the [Arch wiki](https://wiki.archlinux.org/) for documentation not part of this project
+- Report issues/bugs on the [Github issues page](https://github.com/CuBeRJAN/astOS/issues)
 
 #### Base image
-* The snapshot ```0``` is reserved for the base system image, it cannot be changed and can only be updated using ```ast base-update```
+
+- The snapshot `0` is reserved for the base system image, it cannot be changed and can only be updated using `ast base-update`
 
 ## Snapshot Management
 
@@ -122,7 +134,7 @@ python3 main.py /dev/<partition> /dev/<drive> /dev/<efi part> # Skip the EFI par
 ast tree
 ```
 
-* The output can look for example like this:
+- The output can look for example like this:
 
 ```
 root - root
@@ -132,97 +144,110 @@ root - root
         ├── 6 - MATE full desktop
         └── 2*- Plasma full desktop
 ```
-* The asterisk shows which snapshot is currently selected as default
 
-* You can also get only the number of the currently booted snapshot with
+- The asterisk shows which snapshot is currently selected as default
+
+- You can also get only the number of the currently booted snapshot with
 
 ```
 ast current
 ```
+
 #### Add descritption to snapshot
-* Snapshots allow you to add a description to them for easier identification
+
+- Snapshots allow you to add a description to them for easier identification
 
 ```
 ast desc <snapshot> <description>
 ```
+
 #### Delete a tree
-* This removes the tree and all it's branches
+
+- This removes the tree and all it's branches
 
 ```
 ast del <tree>
 ```
+
 #### Custom boot configuration
-* If you need to use a custom grub configuration, chroot into a snapshot and edit ```/etc/default/grub```, then deploy the snapshot and reboot
 
-#### chroot into snapshot 
-* Once inside the chroot the OS behaves like regular Arch, so you can install and remove packages using pacman or similar
-* Do not run ast from inside a chroot, it could cause damage to the system, there is a failsafe in place, which can be bypassed with ```--chroot``` if you really need to (not recommended)  
-* The chroot has to be exited properly with ```exit```, otherwise the changes made will not be saved
-* If you don't exit chroot the "clean" way with ```exit```, it's recommended to run ```ast tmp``` to clear temporary files left behind
+- If you need to use a custom grub configuration, chroot into a snapshot and edit `/etc/default/grub`, then deploy the snapshot and reboot
 
+#### chroot into snapshot
+
+- Once inside the chroot the OS behaves like regular Arch, so you can install and remove packages using pacman or similar
+- Do not run ast from inside a chroot, it could cause damage to the system, there is a failsafe in place, which can be bypassed with `--chroot` if you really need to (not recommended)
+- The chroot has to be exited properly with `exit`, otherwise the changes made will not be saved
+- If you don't exit chroot the "clean" way with `exit`, it's recommended to run `ast tmp` to clear temporary files left behind
 
 ```
 ast chroot <snapshot>
 ```
 
-* You can enter an unlocked shell inside the current booted snapshot with
+- You can enter an unlocked shell inside the current booted snapshot with
 
 ```
 ast live-chroot
 ```
 
-* The changes made to live session are not saved on new deployments 
+- The changes made to live session are not saved on new deployments
 
 #### Other chroot options
 
-* Runs a specified command inside snapshot
+- Runs a specified command inside snapshot
 
 ```
 ast run <snapshot> <command>
 ```
 
-* Runs a specified command inside snapshot and all it's branches
+- Runs a specified command inside snapshot and all it's branches
 
 ```
 ast tree-run <tree> <command>
 ```
 
 #### Clone snapshot
-* This clones the snapshot as a new tree
+
+- This clones the snapshot as a new tree
 
 ```
 ast clone <snapshot>
 ```
+
 #### Create new tree branch
 
-* Adds a new branch to specified snapshot
+- Adds a new branch to specified snapshot
 
 ```
 ast branch <snapshot to branch from>
 ```
+
 #### Clone snapshot under same parent
 
 ```
 ast cbranch <snapshot>
 ```
+
 #### Clone snapshot under specified parent
 
-* Make sure to sync the tree after
+- Make sure to sync the tree after
 
 ```
 ast ubranch <parent> <snapshot>
 ```
+
 #### Create new base tree
 
 ```
 ast new
 ```
-#### Deploy snapshot  
 
-* Reboot to  boot into the new snapshot after deploying
+#### Deploy snapshot
+
+- Reboot to boot into the new snapshot after deploying
 
 ```
-ast deploy <snapshot>  
+ast deploy <snapshot>
 ```
 
 #### Update base which new snapshots are built from
@@ -230,98 +255,104 @@ ast deploy <snapshot>
 ```
 ast base-update
 ```
-* Note: the base itself is located at ```/.snapshots/rootfs/snapshot-0``` with it's specific ```/var``` files and ```/etc``` being located at ```/.snapshots/var/var-0``` and ```/.snapshots/etc/etc-0``` respectively, therefore if you really need to make a configuration change, you can mount snapshot these as read-write and then snapshot back as read only
+
+- Note: the base itself is located at `/.snapshots/rootfs/snapshot-0` with it's specific `/var` files and `/etc` being located at `/.snapshots/var/var-0` and `/.snapshots/etc/etc-0` respectively, therefore if you really need to make a configuration change, you can mount snapshot these as read-write and then snapshot back as read only
 
 ## Package management
 
 #### Software installation
-* Run ```ast deploy <snapshot>``` and reboot after installing new software for changes to apply (unless using live install, more info below)
-* Software can also be installed using pacman in a chroot
-* AUR can be used under the chroot
-* Flatpak can be used for persistent package installation
-* Using containers for additional software installation is also an option. An easy way of doing this is with [distrobox](https://github.com/89luca89/distrobox)
+
+- Run `ast deploy <snapshot>` and reboot after installing new software for changes to apply (unless using live install, more info below)
+- Software can also be installed using pacman in a chroot
+- AUR can be used under the chroot
+- Flatpak can be used for persistent package installation
+- Using containers for additional software installation is also an option. An easy way of doing this is with [distrobox](https://github.com/89luca89/distrobox)
 
 ```
 ast install <snapshot> <package>
 ```
-* After installing you can sync the newly installed packages to all the branches of the tree with
-* Syncing the tree also automatically updates all the snapshots
+
+- After installing you can sync the newly installed packages to all the branches of the tree with
+- Syncing the tree also automatically updates all the snapshots
 
 ```
 ast sync <tree>
 ```
 
-* If you wish to sync without updating (could cause package duplication in database) then use
+- If you wish to sync without updating (could cause package duplication in database) then use
 
 ```
 ast force-sync <tree>
 ```
 
-* ast also supports installing packages without rebooting
+- ast also supports installing packages without rebooting
+
 ```
 ast install --live <snapshot> <package>
 ```
 
 #### Removing software
 
-* For a single snapshot
+- For a single snapshot
 
 ```
 ast remove <snapshot> <package or packages>
 ```
 
-* Recursively
+- Recursively
 
 ```
 ast tree-rmpkg <tree> <pacakge or packages>
 ```
 
-
-
 #### Updating
-* It is advised to clone a snapshot before updating it, so you can roll back in case of failure
 
-* To update a single snapshot
+- It is advised to clone a snapshot before updating it, so you can roll back in case of failure
+
+- To update a single snapshot
 
 ```
 ast upgrade <snapshot>
 ```
-* To recursively update an entire tree
+
+- To recursively update an entire tree
 
 ```
 ast tree-upgrade <tree>
 ```
 
-* This can be configured in a script (ie. a crontab script) for easy and safe automatic updates
+- This can be configured in a script (ie. a crontab script) for easy and safe automatic updates
 
-* If the system becomes unbootable after an update, you can boot last working deployment (select in grub menu) and then perform a rollback
+- If the system becomes unbootable after an update, you can boot last working deployment (select in grub menu) and then perform a rollback
 
 ```
 ast rollback
 ```
 
-* Then you can reboot back to a working system
+- Then you can reboot back to a working system
 
 ## Extras
 
 #### Fixing pacman corrupt packages / key issues
-* Arch's pacman package manager sometimes requires a refresh of the PGP keys
-* To fix this issue we can simply reinstall they arch keyring
+
+- Arch's pacman package manager sometimes requires a refresh of the PGP keys
+- To fix this issue we can simply reinstall they arch keyring
 
 ```
 ast install <snapshots> archlinux-keyring
 ```
 
 #### Dual boot
-* astOS supports dual boot using the GRUB bootloader
-* When installing the system, use the existing EFI partition
-* to configure dual boot, we must begin by installing the ```os-prober``` package:
+
+- astOS supports dual boot using the GRUB bootloader
+- When installing the system, use the existing EFI partition
+- to configure dual boot, we must begin by installing the `os-prober` package:
 
 ```
 ast install <snapshot> os-prober
 ```
 
-* Now we have to configure grub
+- Now we have to configure grub
 
 ```
 ast chroot <snapshot>
@@ -329,25 +360,26 @@ echo 'GRUB_DISABLE_OS_PROBER=false' >> /etc/default/grub
 exit
 ```
 
-* Now just deploy the snapshot to reconfigure the bootloader
+- Now just deploy the snapshot to reconfigure the bootloader
 
 ```
 ast deploy <snapshot>
 ```
 
 #### Updating ast itself
-* sometimes it may be necessary to update ast itself
-* this can be done in a few steps:
+
+- sometimes it may be necessary to update ast itself
+- this can be done in a few steps:
 
 ```
 git clone "https://github.com/CuBeRJAN/astOS"
 cd astOS
-cp astpk.py ast 
+cp astpk.py ast
 chmod +x ast
 cp ./ast /var/astpk/ast  # Copy new ast to /var, accessible from all snapshots
 ast trun <snapshot> cp /var/astpk/ast /usr/local/sbin/ast  # Copy over new ast
 ast clone 0
-ast run <clone of 0> cp /var/astpk/ast /usr/local/sbin/ast  # Now we update snapshot 0 in a clone  
+ast run <clone of 0> cp /var/astpk/ast /usr/local/sbin/ast  # Now we update snapshot 0 in a clone
 btrfs sub del /.snapshots/rootfs/snapshot-0  # Here we manually replace snapshot 0 with the updated snapshot
 btrfs sub snap -r /.snapshots/rootfs/snapshot-<clone of 0> /.snapshots/rootfs/snapshot-0
 ast del <clone of 0>  # Remove temporary snapshot
@@ -355,24 +387,27 @@ ast del <clone of 0>  # Remove temporary snapshot
 
 ## Known bugs
 
-* When running ast without arguments - IndexError: list index out of range
-* Running ast without root permissions shows permission denied errors instead of an error message
-* Swap partition doesn't work, it's recommended to use a swapfile or zram instead
-* Docker has issues with permissions, to fix run
+- When running ast without arguments - IndexError: list index out of range
+- Running ast without root permissions shows permission denied errors instead of an error message
+- Swap partition doesn't work, it's recommended to use a swapfile or zram instead
+- Docker has issues with permissions, to fix run
+
 ```
 sudo chmod 666 /var/run/docker.sock
 ```
 
-* If you run into any issues, report them on [the issues page](https://github.com/CuBeRJAN/astOS/issues)
+- If you run into any issues, report them on [the issues page](https://github.com/CuBeRJAN/astOS/issues)
 
 # Contributing
-* Code and documentation contributions are welcome
-* Bug reports are a good way of contributing to the project too
-* Before submitting a pull request test your code and make sure to comment it properly
+
+- Code and documentation contributions are welcome
+- Bug reports are a good way of contributing to the project too
+- Before submitting a pull request test your code and make sure to comment it properly
 
 # Community
-* Please feel free to join us on [Discord](https://discord.gg/YVHEC6XNZw) for further discussion and support!
-* Happy worry-free snapshotting!
+
+- Please feel free to join us on [Discord](https://discord.gg/YVHEC6XNZw) for further discussion and support!
+- Happy worry-free snapshotting!
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # astOS (Arch Snapshot Tree OS)
-### An immutable Arch based distribution utilizing btrfs snapshots  
+### An immutable Arch based distribution utilizing btrfs snapshots
 
 ![astos-logo](logo.jpg)
 
@@ -14,6 +14,7 @@
   * [Snapshot management and deployments](https://github.com/CuBeRJAN/astOS#snapshot-management)
   * [Package management](https://github.com/CuBeRJAN/astOS#package-management)
 * [Additional documentation](https://github.com/CuBeRJAN/astOS#additional-documentation)
+  * [Updating the pacman keys](https://github.com/CuBeRJAN/astOS#fixing-pacman-corrupt-packages--key-issues)
   * [Configuring dual boot](https://github.com/CuBeRJAN/astOS#dual-boot)
   * [Updating ast itself](https://github.com/CuBeRJAN/astOS#updating-ast-itself)
 * [Known bugs](https://github.com/CuBeRJAN/astOS#known-bugs)
@@ -22,11 +23,11 @@
 
 ---
 
-## What is astOS?  
+## What is astOS?
 
-astOS is a modern distribution based on [Arch Linux](https://archlinux.org).  
+astOS is a modern distribution based on [Arch Linux](https://archlinux.org).
 Unlike Arch it uses an immutable (read-only) root filesystem.  
-Software is installed and configured into individual snapshot trees, which can then be deployed and booted into.  
+Software is installed and configured into individual snapshot trees, which can then be deployed and booted into.
 It doesn't use it's own package format or package manager, instead relying on [pacman](https://wiki.archlinux.org/title/pacman) from Arch.
 
 
@@ -302,6 +303,14 @@ ast rollback
 * Then you can reboot back to a working system
 
 ## Extras
+
+#### Fixing pacman corrupt packages / key issues
+* Arch's pacman package manager sometimes requires a refresh of the PGP keys
+* To fix this issue we can simply reinstall they arch keyring
+
+```
+ast install <snapshots> archlinux-keyring
+```
 
 #### Dual boot
 * astOS supports dual boot using the GRUB bootloader

--- a/README_CZ.md
+++ b/README_CZ.md
@@ -1,81 +1,90 @@
 # astOS (Arch Snapshot Tree OS)
-### Neměnná distribuce založená na archi využívající snapshoty btrfs.  
+
+### Neměnná distribuce založená na archi využívající snapshoty btrfs.
 
 ![astos-logo](logo.jpg)
 
 ---
 
 ## Obsah
-* [Co je astOS?](https://github.com/CuBeRJAN/astOS/blob/main/README_CZ.md#co-je-astos)
-* [astOS ve srovnání s jinými podobnými distribucemi](https://github.com/CuBeRJAN/astOS/blob/main/README_CZ.md#ast-ve-srovnání-s-jinými-podobnými-distribucemi)
-* [dokumentace k ast a astOS](https://github.com/CuBeRJAN/astOS/blob/main/README_CZ.md#dokumentace-k-ast-a-astos)
-  * [Instalace](https://github.com/CuBeRJAN/astOS/blob/main/README_CZ.md#instalace)
-  * [Po instalaci](https://github.com/CuBeRJAN/astOS/blob/main/README_CZ.md#po-instalaci)
-  * [Správa snímků a nasazení](https://github.com/CuBeRJAN/astOS/blob/main/README_CZ.md#správa-snímků)
-  * [Správa balíčků](https://github.com/CuBeRJAN/astOS/blob/main/README_CZ.md#správa-balícků)
-* [Další dokumentace](https://github.com/CuBeRJAN/astOS/blob/main/README_CZ.md#další-dokumentace)
-* [Známé chyby](https://github.com/CuBeRJAN/astOS/blob/main/README_CZ.md#známe-chyby)
-* [Přispívání](https://github.com/CuBeRJAN/astOS/blob/main/README_CZ.md#přispívaní)
+
+- [Co je astOS?](https://github.com/CuBeRJAN/astOS/blob/main/README_CZ.md#co-je-astos)
+- [astOS ve srovnání s jinými podobnými distribucemi](https://github.com/CuBeRJAN/astOS/blob/main/README_CZ.md#ast-ve-srovnání-s-jinými-podobnými-distribucemi)
+- [dokumentace k ast a astOS](https://github.com/CuBeRJAN/astOS/blob/main/README_CZ.md#dokumentace-k-ast-a-astos)
+  - [Instalace](https://github.com/CuBeRJAN/astOS/blob/main/README_CZ.md#instalace)
+  - [Po instalaci](https://github.com/CuBeRJAN/astOS/blob/main/README_CZ.md#po-instalaci)
+  - [Správa snímků a nasazení](https://github.com/CuBeRJAN/astOS/blob/main/README_CZ.md#správa-snímků)
+  - [Správa balíčků](https://github.com/CuBeRJAN/astOS/blob/main/README_CZ.md#správa-balícků)
+- [Další dokumentace](https://github.com/CuBeRJAN/astOS/blob/main/README_CZ.md#další-dokumentace)
+- [Známé chyby](https://github.com/CuBeRJAN/astOS/blob/main/README_CZ.md#známe-chyby)
+- [Přispívání](https://github.com/CuBeRJAN/astOS/blob/main/README_CZ.md#přispívaní)
 
 ---
 
-## Co je astOS?  
+## Co je astOS?
 
 astOS je moderní distribuce založená na [Arch Linuxu](https://archlinux.org).  
 Na rozdíl od Archu používá neměnný (pouze pro čtení) kořenový souborový systém.  
 Software je instalován a konfigurován do jednotlivých stromů snímků, které lze následně nasadit a zavést do systému.  
 Nepoužívá vlastní formát balíčků ani správce balíčků, místo toho se spoléhá na [pacman](https://wiki.archlinux.org/title/pacman) z Archu.
 
-
 **To má několik výhod:**
 
-* Bezpečnost
-  * I když je aplikace spuštěna s vyvýšenímy právy, nemůže nahradit systémové knihovny škodlivými verzemi.
-* Stabilita a spolehlivost
-  * Díky tomu, že je systém připojen pouze pro čtení, není možné omylem přepsat systémové soubory.
-  * Pokud se systém dostane do problémů, můžete během několika minut snadno vrátit poslední funkční snímek.
-  * Atomické aktualizace - aktualizace systému najednou je spolehlivější.
-  * Díky funkci snapshotu může systém astOS dodávat špičkový software, aniž by se stal nestabilním
-  * astOS nepotřebuje téměř žádnou údržbu, protože má vestavěný plně automatický aktualizační nástroj, který před aktualizacemi vytváří snapshoty a před nasazením nového snapshotu automaticky kontroluje, zda se systém správně aktualizoval
-* Konfigurovatelnost
-  * Díky snapshotům uspořádaným do stromu můžete mít snadno k dispozici více různých konfigurací softwaru s různými balíčky, aniž by došlo k jakémukoli zásahu do systému
-  * Například: můžete mít nainstalovanou jednu pracovní plochu Gnome a nad ní mít dva překryvy - jeden s videohrami, s nejnovějším jádrem a ovladači, a druhý pro práci, s jádrem LTS a stabilnějším softwarem, mezi nimiž pak můžete snadno přepínat podle toho, co se snažíte dělat.
-  * Můžete také snadno zkoušet software, aniž byste se museli obávat, že si rozbijete systém nebo ho znečistíte nepotřebnými soubory, například můžete vyzkoušet nové desktopové prostředí ve snapshotu a poté snapshot smazat, aniž byste vůbec měnili svůj hlavní systém.
-  * To lze využít i pro víceuživatelské systémy, kde má každý uživatel zcela samostatný systém s jiným softwarem, a přesto může sdílet určité balíčky, například jádra a ovladače.
-  * astOS umožňuje instalovat software pomocí chrootování do snapshotů, proto můžete k instalaci dalších balíčků použít software, jako je AUR.
-  * astOS je stejně jako Arch velmi přizpůsobitelný, můžete si přesně vybrat software, který chcete používat.
+- Bezpečnost
+  - I když je aplikace spuštěna s vyvýšenímy právy, nemůže nahradit systémové knihovny škodlivými verzemi.
+- Stabilita a spolehlivost
+  - Díky tomu, že je systém připojen pouze pro čtení, není možné omylem přepsat systémové soubory.
+  - Pokud se systém dostane do problémů, můžete během několika minut snadno vrátit poslední funkční snímek.
+  - Atomické aktualizace - aktualizace systému najednou je spolehlivější.
+  - Díky funkci snapshotu může systém astOS dodávat špičkový software, aniž by se stal nestabilním
+  - astOS nepotřebuje téměř žádnou údržbu, protože má vestavěný plně automatický aktualizační nástroj, který před aktualizacemi vytváří snapshoty a před nasazením nového snapshotu automaticky kontroluje, zda se systém správně aktualizoval
+- Konfigurovatelnost
 
-* Díky své spolehlivosti a automatickým aktualizacím je astOS vhodný pro jednorázová nebo vestavěná zařízení.
-* Je také dobrou distribucí pro pracovní stanice nebo obecné použití s využitím vývojových kontejnerů a flatpaku pro desktopové aplikace. 
+  - Díky snapshotům uspořádaným do stromu můžete mít snadno k dispozici více různých konfigurací softwaru s různými balíčky, aniž by došlo k jakémukoli zásahu do systému
+  - Například: můžete mít nainstalovanou jednu pracovní plochu Gnome a nad ní mít dva překryvy - jeden s videohrami, s nejnovějším jádrem a ovladači, a druhý pro práci, s jádrem LTS a stabilnějším softwarem, mezi nimiž pak můžete snadno přepínat podle toho, co se snažíte dělat.
+  - Můžete také snadno zkoušet software, aniž byste se museli obávat, že si rozbijete systém nebo ho znečistíte nepotřebnými soubory, například můžete vyzkoušet nové desktopové prostředí ve snapshotu a poté snapshot smazat, aniž byste vůbec měnili svůj hlavní systém.
+  - To lze využít i pro víceuživatelské systémy, kde má každý uživatel zcela samostatný systém s jiným softwarem, a přesto může sdílet určité balíčky, například jádra a ovladače.
+  - astOS umožňuje instalovat software pomocí chrootování do snapshotů, proto můžete k instalaci dalších balíčků použít software, jako je AUR.
+  - astOS je stejně jako Arch velmi přizpůsobitelný, můžete si přesně vybrat software, který chcete používat.
+
+- Díky své spolehlivosti a automatickým aktualizacím je astOS vhodný pro jednorázová nebo vestavěná zařízení.
+- Je také dobrou distribucí pro pracovní stanice nebo obecné použití s využitím vývojových kontejnerů a flatpaku pro desktopové aplikace.
 
 ---
+
 ## astOS ve srovnání s jinými podobnými distribucemi
-* **NixOS** - ve srovnání s nixOS je astOS tradičnější systém, co se týče nastavení a údržby. Zatímco nixOS je kompletně konfigurován pomocí programovacího jazyka Nix, astOS používá správce balíčků Arch pacman. astOS používá snímky btrfs.
-  * astOS umožňuje deklarativní konfiguraci pomocí Ansible, pro podobnou funkčnost jako NixOS.
-* **Fedora Silverblue** - astOS je lépe přizpůsobitelný, ale vyžaduje více ručního nastavení.
-* **OpenSUSE MicroOS** - astOS je více přizpůsobitelný systém, ale opět vyžaduje trochu více ručního nastavení. MicroOS funguje podobně jako astOS ve způsobu, jakým využívá snímky btrfs.
+
+- **NixOS** - ve srovnání s nixOS je astOS tradičnější systém, co se týče nastavení a údržby. Zatímco nixOS je kompletně konfigurován pomocí programovacího jazyka Nix, astOS používá správce balíčků Arch pacman. astOS používá snímky btrfs.
+  - astOS umožňuje deklarativní konfiguraci pomocí Ansible, pro podobnou funkčnost jako NixOS.
+- **Fedora Silverblue** - astOS je lépe přizpůsobitelný, ale vyžaduje více ručního nastavení.
+- **OpenSUSE MicroOS** - astOS je více přizpůsobitelný systém, ale opět vyžaduje trochu více ručního nastavení. MicroOS funguje podobně jako astOS ve způsobu, jakým využívá snímky btrfs.
 
 ---
+
 ## Instalace
-* astOS se instaluje z oficiálního Live iso Arch Linuxu dostupného na [https://archlinux.org/](https://archlinux.org).
+
+- astOS se instaluje z oficiálního Live iso Arch Linuxu dostupného na [https://archlinux.org/](https://archlinux.org).
 
 Nejprve nainstalujte git - to nám umožní stáhnout instalační skript.
 
 ```
 pacman -Sy git
 ```
+
 Klonování repozitáře
 
 ```
-git clone "https://github.com/CuBeRJAN/astOS"  
-cd astOS  
+git clone "https://github.com/CuBeRJAN/astOS"
+cd astOS
 ```
+
 Rozdělení a formátování disku
 
 ```
 lsblk # Zjistěte název jednotky
-cfdisk /dev/*** # naformátujte disk, nezapomeňte přidat oddíl EFI, pokud používáte BIOS, nechte před oddílem 2M pro bootloader  
+cfdisk /dev/*** # naformátujte disk, nezapomeňte přidat oddíl EFI, pokud používáte BIOS, nechte před oddílem 2M pro bootloader
 ```
+
 Spusťte instalační program
 
 ```
@@ -83,24 +92,27 @@ python3 main.py /dev/<oddíl> /dev/<disk> /dev/<efi oddíl> # V případě insta
 ```
 
 ## Nastavení po instalaci
-* astOS neprovádí mnoho nastavení pro uživatele, proto bude nutné provést nějaké nastavení po instalaci.
-* Mnoho informací o tom, jak zvládnout poinstalační nastavení, je k dispozici na stránce [ArchWiki](https://wiki.archlinux.org/title/general_recommendations). 
-* Zde je malý příklad postupu nastavení:
-  * Začněte vytvořením nového snímku ze základního obrazu pomocí ```ast clone 0```)
-  * Uvnitř tohoto nového snapshotu proveďte chroot (```ast chroot <snapshot>```) a začněte s nastavováním.
-    * Začněte přidáním nového uživatelského účtu: ```useradd username```
-    * Nastavte uživatelské heslo ```passwd username```
-    * Nyní nastavte nové heslo pro uživatele root ```passwd root```
-    * Nyní můžete pomocí programu pacman nainstalovat další balíčky (desktopová prostředí, kontejnerové technologie, flatpak).
-    * Po dokončení ukončete chroot pomocí ```exit```
-    * Poté jej můžete nasadit pomocí ```ast deploy <snapshot>```
+
+- astOS neprovádí mnoho nastavení pro uživatele, proto bude nutné provést nějaké nastavení po instalaci.
+- Mnoho informací o tom, jak zvládnout poinstalační nastavení, je k dispozici na stránce [ArchWiki](https://wiki.archlinux.org/title/general_recommendations).
+- Zde je malý příklad postupu nastavení:
+  - Začněte vytvořením nového snímku ze základního obrazu pomocí `ast clone 0`)
+  - Uvnitř tohoto nového snapshotu proveďte chroot (`ast chroot <snapshot>`) a začněte s nastavováním.
+    - Začněte přidáním nového uživatelského účtu: `useradd username`
+    - Nastavte uživatelské heslo `passwd username`
+    - Nyní nastavte nové heslo pro uživatele root `passwd root`
+    - Nyní můžete pomocí programu pacman nainstalovat další balíčky (desktopová prostředí, kontejnerové technologie, flatpak).
+    - Po dokončení ukončete chroot pomocí `exit`
+    - Poté jej můžete nasadit pomocí `ast deploy <snapshot>`
 
 ## Další dokumentace
-* Doporučujeme podívat se na [Arch wiki](https://wiki.archlinux.org/), kde najdete dokumentaci, která není součástí tohoto projektu.
-* Nahlášení problémů/chyb na [Github issues page](https://github.com/CuBeRJAN/astOS/issues).
+
+- Doporučujeme podívat se na [Arch wiki](https://wiki.archlinux.org/), kde najdete dokumentaci, která není součástí tohoto projektu.
+- Nahlášení problémů/chyb na [Github issues page](https://github.com/CuBeRJAN/astOS/issues).
 
 #### Základní obraz
-* Snímek ```0``` je vyhrazen pro základní obraz systému, nelze jej měnit a lze jej aktualizovat pouze pomocí ```ast base-update```.
+
+- Snímek `0` je vyhrazen pro základní obraz systému, nelze jej měnit a lze jej aktualizovat pouze pomocí `ast base-update`.
 
 ## Správa snímků
 
@@ -110,7 +122,7 @@ python3 main.py /dev/<oddíl> /dev/<disk> /dev/<efi oddíl> # V případě insta
 ast strom
 ```
 
-* Výstup může vypadat například takto:
+- Výstup může vypadat například takto:
 
 ```
 root - kořen
@@ -120,31 +132,39 @@ root - kořen
         ├── 6 - plná pracovní plocha MATE
         └── 2*- plná pracovní plocha Plasma
 ```
-* Hvězdička ukazuje, který snímek je aktuálně zvolen jako výchozí
 
-* Můžete také získat pouze číslo aktuálně spuštěného snapshotu pomocí příkazu
+- Hvězdička ukazuje, který snímek je aktuálně zvolen jako výchozí
+
+- Můžete také získat pouze číslo aktuálně spuštěného snapshotu pomocí příkazu
 
 ```
 ast current
 ```
+
 #### Přidání popisu ke snímku
-* Snímky umožňují přidat k nim popis pro snadnější identifikaci.
+
+- Snímky umožňují přidat k nim popis pro snadnější identifikaci.
 
 ```
 ast desc <snímek> <popis>
 ```
+
 #### Odstranění stromu
-* Odstraní strom a všechny jeho větve.
+
+- Odstraní strom a všechny jeho větve.
 
 ```
 ast del <strom>
 ```
-#### Vlastní konfigurace spouštění
-* Pokud potřebujete použít vlastní konfiguraci grubu, chrootněte se do snapshotu a upravte ```/etc/default/grub```, poté snapshot nasaďte a restartujte počítač.
 
-#### chroot do snapshotu 
-* Po vstupu do chrootu se operační systém chová jako běžný Arch, takže můžete instalovat a odebírat balíčky pomocí pacmanu nebo podobného nástroje.
-* Nespouštějte ast zevnitř chrootu, mohlo by dojít k poškození systému, je zde pojistka proti selhání, kterou lze obejít pomocí ```--chroot```, pokud to opravdu potřebujete (nedoporučuje se).  
+#### Vlastní konfigurace spouštění
+
+- Pokud potřebujete použít vlastní konfiguraci grubu, chrootněte se do snapshotu a upravte `/etc/default/grub`, poté snapshot nasaďte a restartujte počítač.
+
+#### chroot do snapshotu
+
+- Po vstupu do chrootu se operační systém chová jako běžný Arch, takže můžete instalovat a odebírat balíčky pomocí pacmanu nebo podobného nástroje.
+- Nespouštějte ast zevnitř chrootu, mohlo by dojít k poškození systému, je zde pojistka proti selhání, kterou lze obejít pomocí `--chroot`, pokud to opravdu potřebujete (nedoporučuje se).
 
 ```
 ast chroot <snapshot>
@@ -152,77 +172,86 @@ ast chroot <snapshot>
 
 #### Další možnosti chrootu
 
-* Spustí příkaz ve snapshotu
+- Spustí příkaz ve snapshotu
 
 ```
 ast run <snapshot> <příkaz>
 ```
 
-* Spustí příkaz ve snapshotu a všech jeho podvětvích
+- Spustí příkaz ve snapshotu a všech jeho podvětvích
 
 ```
 ast tree-run <strom> <příkaz>
 ```
 
-
 #### Klonování snímku
-* Klonuje snapshot jako nový strom.
+
+- Klonuje snapshot jako nový strom.
 
 ```
 ast clone <snapshot>
 ```
+
 #### Vytvoří novou větev stromu
 
-* Přidá novou větev k zadanému snímku.
+- Přidá novou větev k zadanému snímku.
 
 ```
 ast branch <snapshot, z něhož se má větev vytvořit>
 ```
+
 #### Klonování snímku pod stejným rodičem
 
 ```
 ast cbranch <snapshot>
 ```
+
 #### Klonování snímku pod zadaným rodičem
 
-* Nezapomeňte po této funkci synchronizovat strom
-* Rodič je větev pod kterou chcete klonovat
+- Nezapomeňte po této funkci synchronizovat strom
+- Rodič je větev pod kterou chcete klonovat
 
 ```
 ast ubranch <rodič> <snapshot>
 ```
+
 #### Vytvoření nového základního stromu
 
 ```
 ast new
 ```
-#### Nasadit snímek  
 
-* Po nasazení restartujte systém, abyste nabootovali do nového snapshotu.
+#### Nasadit snímek
+
+- Po nasazení restartujte systém, abyste nabootovali do nového snapshotu.
 
 ```
-ast deploy <snapshot>  
+ast deploy <snapshot>
 ```
+
 #### Aktualizovat základnu, ze které se sestavují nové snapshoty
 
 ```
 ast base-update
 ```
-* Poznámka: samotná báze je umístěna na ```/.snapshots/snapshot-0```, přičemž její specifické soubory ```/var``` a ```/etc``` jsou umístěny na ```/.var/var-0``` a ```/.etc/etc-0```, proto pokud opravdu potřebujete provést změnu konfigurace, můžete tyto snapshoty připojit jako read-write a poté snapshoty zpět jako read only
+
+- Poznámka: samotná báze je umístěna na `/.snapshots/snapshot-0`, přičemž její specifické soubory `/var` a `/etc` jsou umístěny na `/.var/var-0` a `/.etc/etc-0`, proto pokud opravdu potřebujete provést změnu konfigurace, můžete tyto snapshoty připojit jako read-write a poté snapshoty zpět jako read only
 
 ## Správa balíčků
 
 #### Instalace softwaru
-* Po instalaci nového softwaru spusťte ```ast deploy <snapshot>``` a restartujte počítač, aby se změny uplatnily.
-* Software lze také nainstalovat pomocí pacmanu do chrootu
-* Pod chrootem lze použít AUR
-* Pro trvalou instalaci balíčků lze použít Flatpak
-* Použití kontejnerů pro instalaci dalšího softwaru je také možností, výhodou je, že není třeba restartovat počítač. Doporučeným způsobem je použití [distrobox](https://github.com/89luca89/distrobox).
+
+- Po instalaci nového softwaru spusťte `ast deploy <snapshot>` a restartujte počítač, aby se změny uplatnily.
+- Software lze také nainstalovat pomocí pacmanu do chrootu
+- Pod chrootem lze použít AUR
+- Pro trvalou instalaci balíčků lze použít Flatpak
+- Použití kontejnerů pro instalaci dalšího softwaru je také možností, výhodou je, že není třeba restartovat počítač. Doporučeným způsobem je použití [distrobox](https://github.com/89luca89/distrobox).
 
 ```
 ast install <snapshot> <balíček>
 ```
-* Po instalaci můžete synchronizovat nově nainstalované balíčky do všech větví stromu pomocí příkazu
+
+- Po instalaci můžete synchronizovat nově nainstalované balíčky do všech větví stromu pomocí příkazu
 
 ```
 ast sync <strom>
@@ -230,55 +259,56 @@ ast sync <strom>
 
 #### Odtraňování softwaru
 
-* Pro jediný snapshot
+- Pro jediný snapshot
 
 ```
 ast remove <snapshot> <balíček či balíčky>
 ```
 
-* Rekurzivně
+- Rekurzivně
 
 ```
 ast tree-rmpkg <strom> <balíček či balíčky>
 ```
 
-
-
-
 #### Aktualizace
-* Před aktualizací se doporučuje klonovat snímek, abyste se mohli v případě selhání vrátit zpět.
 
-* Aktualizace jednoho snímku
+- Před aktualizací se doporučuje klonovat snímek, abyste se mohli v případě selhání vrátit zpět.
+
+- Aktualizace jednoho snímku
 
 ```
 ast upgrade <snapshot>
 ```
-* Pro rekurzivní aktualizaci celého stromu
+
+- Pro rekurzivní aktualizaci celého stromu
 
 ```
 ast tree-update <strom>
 ```
 
-* Tuto funkci lze nakonfigurovat ve skriptu (tj. ve skriptu crontab) pro snadné a bezpečné automatické aktualizace.
+- Tuto funkci lze nakonfigurovat ve skriptu (tj. ve skriptu crontab) pro snadné a bezpečné automatické aktualizace.
 
 ## Známé chyby
 
-* Při spuštění ast bez argumentů - IndexError: index seznamu mimo rozsah
-* Při spuštění ast bez práv roota se místo chybové zprávy zobrazí chyba s odepřenými právy.
-* GDM a LightDM nemusí fungovat
-* Při zapnutí a vypnutí systému "Error: failed to remount root and boot filesystems"
-* Nefunuguje swap oddíl, je doporučeno použít swapfile nebo zram  
-* Docker má problémy s oprávněními, pro opravu spusťte
+- Při spuštění ast bez argumentů - IndexError: index seznamu mimo rozsah
+- Při spuštění ast bez práv roota se místo chybové zprávy zobrazí chyba s odepřenými právy.
+- GDM a LightDM nemusí fungovat
+- Při zapnutí a vypnutí systému "Error: failed to remount root and boot filesystems"
+- Nefunuguje swap oddíl, je doporučeno použít swapfile nebo zram
+- Docker má problémy s oprávněními, pro opravu spusťte
 
 ```
 sudo chmod 666 /var/run/docker.sock
 ```
-* Pokud narazíte na nějaké problémy, nahlaste je na [stránce problémů](https://github.com/CuBeRJAN/astOS/issues).
+
+- Pokud narazíte na nějaké problémy, nahlaste je na [stránce problémů](https://github.com/CuBeRJAN/astOS/issues).
 
 # Přispívání
-* Příspěvky do kódu a dokumentace jsou vítány
-* Dobrým způsobem, jak přispět k projektu, je také hlášení chyb.
-* Před odesláním pull requestu kód otestujte a ujistěte se, že je řádně okomentován.
+
+- Příspěvky do kódu a dokumentace jsou vítány
+- Dobrým způsobem, jak přispět k projektu, je také hlášení chyb.
+- Před odesláním pull requestu kód otestujte a ujistěte se, že je řádně okomentován.
 
 ---
 

--- a/astpk.py
+++ b/astpk.py
@@ -652,7 +652,7 @@ def switchtmp():
     part = get_part()
     # This part is useless? Dumb stuff
     os.system(f"mkdir -p /etc/mnt/boot >/dev/null 2>&1")
-    os.system(f"mount {part} -o subvol=@boot /etc/mnt/boot ") # Mount boot partition for writing
+    os.system(f"mount {part} -o subvol=@boot /etc/mnt/boot") # Mount boot partition for writing
     if "tmp0" in mount:
         os.system("cp --reflink=auto -r /.snapshots/rootfs/snapshot-tmp/boot/* /etc/mnt/boot")
         os.system("sed -i 's,@.snapshots/rootfs/snapshot-tmp0,@.snapshots/rootfs/snapshot-tmp,g' /etc/mnt/boot/grub/grub.cfg") # Overwrite grub config boot subvolume

--- a/main.py
+++ b/main.py
@@ -254,8 +254,8 @@ def main(args):
     else:
         os.system("btrfs sub snap /mnt/.snapshots/rootfs/snapshot-0 /mnt/.snapshots/rootfs/snapshot-tmp")
 
-    os.system("cp -r /mnt/root/* /mnt/.snapshots/root/")
-    os.system("cp -r /mnt/tmp/* /mnt/.snapshots/tmp/")
+    os.system("cp -r /mnt/root/. /mnt/.snapshots/root/")
+    os.system("cp -r /mnt/tmp/. /mnt/.snapshots/tmp/")
     os.system("rm -rf /mnt/root/*")
     os.system("rm -rf /mnt/tmp/*")
 #    os.system("umount /mnt/var")

--- a/main.py
+++ b/main.py
@@ -255,7 +255,7 @@ def main(args):
         os.system("btrfs sub snap /mnt/.snapshots/rootfs/snapshot-0 /mnt/.snapshots/rootfs/snapshot-tmp")
 
     os.system("cp -r /mnt/root/* /mnt/.snapshots/root/")
-    os.system("cp -r /mnt/root/* /mnt/.snapshots/tmp/")
+    os.system("cp -r /mnt/tmp/* /mnt/.snapshots/tmp/")
     os.system("rm -rf /mnt/root/*")
     os.system("rm -rf /mnt/tmp/*")
 #    os.system("umount /mnt/var")


### PR DESCRIPTION
- Fixed typo: /mnt/tmp was incorrectly typed as /mnt/root
- switched README.md line ending from CRLF to LR
- Beautified README.md (redundant spaces, etc.)